### PR TITLE
Better opts handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,11 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/Alethio/cms-plugin-tool"
   },
   "dependencies": {
+    "commander": "^2.20.0",
     "fs-extra": "^8.0.1",
     "pacote": "^9.5.0",
     "tar": "^4.4.10",


### PR DESCRIPTION
- Use `commander` for advanced command-line opts/args handling
- Improve usage and option descriptions
- Add more verbose output.