### PR TITLE
Improve boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Add uninstall command for easily removing installed plugins
 - Add rename command for easily changing the publisher, the plugin name or the npm package name of the plugin
 - Behavior changed for `acp install`. It will now overwrite existing plugins when switching to/from `--dev` mode.
-- Behavior change for `acp init`. Order of the parameters was changed. `npm_package_name` is now the last parameter and is optional. `npm install` is automatically executed after the boilerplate is generated.
+- Behavior change for `acp init`. `npm_package_name` is now the last argument and is optional. `npm install` is automatically executed after generating the boilerplate.
 - More verbose command output
 - Add default .gitignore and .npmignore files to generated boilerplate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
 - Add uninstall command for easily removing installed plugins
+- Add rename command for easily changing the publisher, the plugin name or the npm package name of the plugin
 - Behavior changed for `acp install`. It will now overwrite existing plugins when switching to/from `--dev` mode.
+- Behavior change for `acp init`. Order of the parameters was changed. `npm_package_name` is now the last parameter and is optional. `npm install` is automatically executed after the boilerplate is generated.
 - More verbose command output
+- Add default .gitignore and .npmignore files to generated boilerplate.
 
 # v1.0.0-beta.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 - Add uninstall command for easily removing installed plugins
 - Add rename command for easily changing the publisher, the plugin name or the npm package name of the plugin
-- Behavior changed for `acp install`. It will now overwrite existing plugins when switching to/from `--dev` mode.
-- Behavior change for `acp init`. `npm_package_name` is now the last argument and is optional. `npm install` is automatically executed after generating the boilerplate.
 - More verbose command output
+- Better command options parsing and usage printing
 - Add default .gitignore and .npmignore files to generated boilerplate.
+
+## Breaking changes
+- (`acp init`): `npm_package_name` is now the last argument and is optional.
+- (`acp init`): `npm install` is automatically executed after generating the boilerplate.
+- (`acp install`): will now overwrite existing plugin installations when switching to/from `--dev` mode.
 
 # v1.0.0-beta.3
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,73 @@
 
 Command-line tool for installing/bootstrapping Alethio CMS plugins
 
+## Installing the tool
+
 `$ npm install -g @alethio/cms-plugin-tool`
 
-`$ acp` for usage
+*NOTE*: When using the tool in a deployment pipeline, we recommend specifying a fixed version instead of the implicit `latest` dist-tag.
 
-## Testing plugins locally
+## Usage
 
-Option 1: `acp link <plugin_path>` will symlink the plugin so we don't have to re-install it on every change.
+See `$ acp -h` for available commands.
 
-Option 2: `acp install --dev <package_spec>` will fully install the plugin from an npm package. See `npm install` for the format of `package_spec`.
+See `$ acp [command] -h` for usage on each command.
 
-## Creating plugin boilerplate
+## Use cases
 
-Create a blank folder and switch to it. Run the following:
+### Testing/developing plugins locally
 
-`$ acp init <plugin_npm_package_name> <publisher> <pluginName>`
+There are two methods of installing a plugin for local development:
+
+We assume the current directory is the checkout of the host app, which uses the default `dist/plugins` target.
+
+**Method 1**: `acp link <plugin_path...>` will symlink the plugin(s) found at the specified path so we don't have to re-install on every change.
+
+*Example*: `$ acp link ~/workspace/my-plugin-checkout`
+
+**Method 2**: `acp install --dev <package_spec...>` will install plugin(s) from npm / GitHub / local path etc. See [npm install](https://docs.npmjs.com/cli/install) for the format of `package_spec`.
+
+*Example*: `$ acp install --dev @my-npm-scope/my-plugin MyGitHubHandle/my-other-plugin ~/workspace/my-local-plugin`
+
+### Installing plugins for production
+
+`acp install <package_spec...>` will install plugin(s) from npm / GitHub / local path etc. See [npm install](https://docs.npmjs.com/cli/install) for the format of `package_spec`.
+
+*Example*: `$ acp install @my-npm-scope/my-plugin MyGitHubHandle/my-other-plugin ~/workspace/my-local-plugin`
+
+**NOTE**: If the plugin is installed from a source different than npm, it will be built ad-hoc, using the "prepare" script in its package.json manifest. Also, if a "dist" folder is found, it will be used instead.
+
+### Uninstalling plugins
+
+You can simply delete the plugin folders under the `dist/plugins` path in your host app or run the `acp uninstall` command.
+
+*Example*: In your host app checkout folder run `$ acp uninstall @my-npm-scope/my-plugin@1.0.0`
+
+### Creating plugin boilerplate
+
+Create a blank folder for your plugin and switch to it. Run the following:
+
+`$ acp init <publisher> <pluginName> [plugin_npm_package_name]`
 
 or, if you prefer vanilla JavaScript instead of TypeScript:
 
-`$ acp init --js <plugin_npm_package_name> <publisher> <pluginName>`
+`$ acp init --js <publisher> <pluginName> [plugin_npm_package_name]`
 
-Finally, install the plugin dependencies and build it:
+*NOTES*:
+- `plugin_npm_package_name` is only needed if you plan to publish your plugin to npm. You can also manually add it later in your package.json.
+- The `init` command will also install the plugin dependencies for you and build the initial version.
 
-`$ npm install`
-`$ npm run watch` for development or `$ npm run build` for minified build.
+You can then re-build the plugin when making changes with:
+
+- `$ npm run watch` for development
+- `$ npm run build` for minified production build
+
+### Renaming a plugin
+
+You can change the plugin or publisher names, or even the npm package name using the `acp rename` command.
+
+In your plugin folder execute:
+
+`$ acp rename <publisher> <plugin_name> [npm_package_name]`
+
+*NOTE*: If you don't specify `npm_package_name` it will be assumed blank and be removed from package.json. `npm install` is also executed after a successful operation.

--- a/boilerplate/git/gitignore.tpl
+++ b/boilerplate/git/gitignore.tpl
@@ -1,0 +1,5 @@
+npm-debug.log
+node_modules
+dist
+.idea
+.DS_Store

--- a/boilerplate/js/.npmignore
+++ b/boilerplate/js/.npmignore
@@ -1,0 +1,2 @@
+.*
+webpack.config*.js

--- a/boilerplate/ts/.npmignore
+++ b/boilerplate/ts/.npmignore
@@ -1,0 +1,4 @@
+.*
+tslint*.json
+tsconfig.json
+webpack.config*.js

--- a/index.js
+++ b/index.js
@@ -90,17 +90,17 @@ program
     }));
 
 program
-    .command("init <npm_package_name> <publisher> <plugin_name>")
-    .description("Generates plugin boilerplate in the current folder. IMPORTANT: Any existing files will be overwritten.", {
+    .command("init <publisher> <plugin_name> [npm_package_name]")
+    .description("Generates plugin boilerplate in the current folder. IMPORTANT: Folder must be empty.", {
         "npm_package_name": "Package name that will be used in the generated package.json. Useful if the plugin will be distributed via npm.",
         "publisher": "A handle identifying the publisher of the plugin. It should be something unique, like the domain-name of an organization or a user's GitHub handle.",
         "plugin_name": "The name of the plugin. The CMS will reference the plugin by this name, together with the publisher (e.g. plugin://publisher/plugin_name)."
     })
     .option("--js", "should the init command generate JavaScript boilerplate instead of TypeScript boilerplate?")
-    .action(wrapErrors(async (npmPackageName, publisher, pluginName, cmd) => {
+    .action(wrapErrors(async (publisher, pluginName, npmPackageName = "", cmd) => {
         let jsMode = cmd.js;
 
-        if (!validateNpmPackageName(npmPackageName).validForNewPackages) {
+        if (npmPackageName && !validateNpmPackageName(npmPackageName).validForNewPackages) {
             throw new UserError(`Invalid npm package name "${npmPackageName}"`);
         }
         validatePublisherName(publisher);
@@ -155,6 +155,8 @@ function createBoilerplate(
         packageJsonPath,
         fs.readFileSync(packageJsonPath, { encoding: "utf-8"})
             .replace(/<package_name>/g, npmPackageName)
+            // if npmPackageName is not set, omit "name" field entirely
+            .replace(/\s"name": "",\n/, "")
             .replace(/<publisher>/g, publisher)
             .replace(/<plugin_name>/g, pluginName)
     );

--- a/index.js
+++ b/index.js
@@ -111,6 +111,25 @@ program
         process.stdout.write("Done.\n");
     }));
 
+program
+    .command("rename <publisher> <plugin_name> [npm_package_name]")
+    .description("Renames the plugin, by updating all references in the plugin manifest and webpack configuration", {
+        "npm_package_name": "Package name that will be used in the generated package.json. Useful if the plugin will be distributed via npm.",
+        "publisher": "A handle identifying the publisher of the plugin. It should be something unique, like the domain-name of an organization or a user's GitHub handle.",
+        "plugin_name": "The name of the plugin. The CMS will reference the plugin by this name, together with the publisher (e.g. plugin://publisher/plugin_name)."
+    })
+    .action(wrapErrors(async (publisher, pluginName, npmPackageName = "", cmd) => {
+        if (npmPackageName && !validateNpmPackageName(npmPackageName).validForNewPackages) {
+            throw new UserError(`Invalid npm package name "${npmPackageName}"`);
+        }
+        validatePublisherName(publisher);
+        validatePluginName(pluginName);
+
+        process.stdout.write(`\n> Rename target plugin to "${publisher}/${pluginName}":\n\n`);
+        renamePlugin(npmPackageName, publisher, pluginName, process.cwd());
+        process.stdout.write("Done.\n");
+    }));
+
 program.on("command:*", () => {
     program.outputHelp();
     process.exit(1);
@@ -136,12 +155,6 @@ function createBoilerplate(
         throw new UserError(`Can't create boilerplate in a non-empty folder.`);
     }
 
-    // HACK: this is a copy paste from @alethio/cms package
-    let pluginLibraryName = "__" + (publisher + "/" + pluginName)
-        .replace(/\./g, "_")
-        .replace(/\//g, "__")
-        .replace(/-([a-z])/gi, (match, capture) => capture.toUpperCase());
-
     fs.copySync(path.join(__dirname, "boilerplate", jsMode ? "js" : "ts"), targetPath);
 
     if (!fs.existsSync(path.join(targetPath, ".gitignore"))) {
@@ -151,26 +164,77 @@ function createBoilerplate(
         );
     }
 
-    fs.writeFileSync(
-        packageJsonPath,
-        fs.readFileSync(packageJsonPath, { encoding: "utf-8"})
-            .replace(/<package_name>/g, npmPackageName)
-            // if npmPackageName is not set, omit "name" field entirely
-            .replace(/\s"name": "",\n/, "")
-            .replace(/<publisher>/g, publisher)
-            .replace(/<plugin_name>/g, pluginName)
-    );
-    fs.writeFileSync(
-        webpackConfigPath,
-        fs.readFileSync(webpackConfigPath, { encoding: "utf-8" })
-            .replace(/<library_name>/g, pluginLibraryName)
-    );
+    patchPluginFiles(packageJsonPath, webpackConfigPath, npmPackageName, publisher, pluginName);
 
     process.stdout.write(`Created boilerplate in working directory.\n`);
 
     let npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
     process.stdout.write(`Running npm install...\n`);
     child_process.spawnSync(npmCmd, ["install"], { cwd: targetPath, stdio: "inherit" });
+}
+
+async function renamePlugin(
+    /** @type string */ npmPackageName,
+    /** @type string */ publisher,
+    /** @type string */ pluginName,
+    /** @type string */ targetPath
+) {
+    let packageJsonPath = path.join(targetPath, "package.json");
+    let webpackConfigPath = path.join(targetPath, "webpack.config.js");
+
+    if (!fs.existsSync(packageJsonPath) || !fs.existsSync(webpackConfigPath)) {
+        throw new UserError(`Couldn't find a valid plugin in "${targetPath}"`);
+    }
+
+    patchPluginFiles(packageJsonPath, webpackConfigPath, npmPackageName, publisher, pluginName);
+
+    process.stdout.write(`Updated "package.json" and "webpack.config.js".\n`);
+
+    let npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    process.stdout.write(`Running npm install...\n`);
+    child_process.spawnSync(npmCmd, ["install"], { cwd: targetPath, stdio: "inherit" });
+}
+
+async function patchPluginFiles(
+    /** @type string */packageJsonPath,
+    /** @type string */webpackConfigPath,
+    /** @type string */npmPackageName,
+    /** @type string */publisher,
+    /** @type string */pluginName
+) {
+    let packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: "utf-8" }));
+
+    if (npmPackageName && packageJson.name === void 0) {
+        // Ensure name is added at the top
+        packageJson = { name: npmPackageName, ...packageJson };
+    } else {
+        // if npmPackageName is not set, omit "name" field entirely
+        packageJson.name = npmPackageName || void 0;
+    }
+
+    packageJson.publisher = publisher;
+    packageJson.pluginName = pluginName;
+
+    if (packageJson.author === "<publisher>") {
+        packageJson.author = publisher;
+    }
+
+    fs.writeFileSync(
+        packageJsonPath,
+        JSON.stringify(packageJson, void 0, " ".repeat(2))
+    );
+
+    // HACK: this is a copy paste from @alethio/cms package
+    let pluginLibraryName = "__" + (publisher + "/" + pluginName)
+        .replace(/\./g, "_")
+        .replace(/\//g, "__")
+        .replace(/-([a-z])/gi, (match, capture) => capture.toUpperCase());
+
+    fs.writeFileSync(
+        webpackConfigPath,
+        fs.readFileSync(webpackConfigPath, { encoding: "utf-8" })
+            .replace(/(output:\s+{[\s\S]*library:\s*)"([^"]+)"/g, `$1"${pluginLibraryName}"`)
+    );
 }
 
 async function installPlugin(

--- a/index.js
+++ b/index.js
@@ -143,6 +143,14 @@ function createBoilerplate(
         .replace(/-([a-z])/gi, (match, capture) => capture.toUpperCase());
 
     fs.copySync(path.join(__dirname, "boilerplate", jsMode ? "js" : "ts"), targetPath);
+
+    if (!fs.existsSync(path.join(targetPath, ".gitignore"))) {
+        fs.copySync(
+            path.join(__dirname, "boilerplate", "git", "gitignore.tpl"),
+            path.join(targetPath, ".gitignore")
+        );
+    }
+
     fs.writeFileSync(
         packageJsonPath,
         fs.readFileSync(packageJsonPath, { encoding: "utf-8"})

--- a/index.js
+++ b/index.js
@@ -164,6 +164,11 @@ function createBoilerplate(
             .replace(/<library_name>/g, pluginLibraryName)
     );
 
+    process.stdout.write(`Created boilerplate in working directory.\n`);
+
+    let npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    process.stdout.write(`Running npm install...\n`);
+    child_process.spawnSync(npmCmd, ["install"], { cwd: targetPath, stdio: "inherit" });
 }
 
 async function installPlugin(


### PR DESCRIPTION
- Add rename command for easily changing the publisher, the plugin name or the npm package name of the plugin
- Behavior change for `acp init`. `npm_package_name` is now the last argument and is optional. `npm install` is automatically executed after the boilerplate is generated.
- Add default .gitignore and .npmignore files to generated boilerplate.